### PR TITLE
Remove team handbook link

### DIFF
--- a/team.html
+++ b/team.html
@@ -33,9 +33,6 @@ redirect_from:
         and keep Rocket.Chat always aimed towards the next level. Get to know each of
         them below.
       </p>
-      <p>
-        <a href="http://localhost:4000/handbook/">Team Handbook</a>  (WIP).
-      </p>
     </div>
     <div class="right">
       <img src="/images/index/community.svg" alt="">


### PR DESCRIPTION
Not sure this link should be live or not, in any case it is pointing to `localhost` and have a `WIP` flag, so I'm proposing its removal.