### PR TITLE
Fix cloud plan links

### DIFF
--- a/cloud.html
+++ b/cloud.html
@@ -173,7 +173,7 @@ redirect_from:
             </p>
             <p class="theme_type--light">For new &amp; small teams or small communities</p>
             <br />
-            <a class="button" target="_blank" rel="noopener noreferrer" href="//cloud.rocket.chat/trial/small">Start trial</a>
+            <a class="button" target="_blank" rel="noopener noreferrer" href="//cloud.rocket.chat/trial/medium">Start trial</a>
           </td>
         </tr>
         <tr>
@@ -181,7 +181,7 @@ redirect_from:
         </tr>
         <tr>
           <td>
-            <p>5.000 users</p>
+            <p>5,000 users</p>
             <p>Up to 200 concurrent users </p>
           </td>
         </tr>
@@ -231,7 +231,7 @@ redirect_from:
             </p>
             <p class="theme_type--light">For new &amp; small teams or small communities</p>
             <br />
-            <a class="button" target="_blank" rel="noopener noreferrer" href="//cloud.rocket.chat/trial/small">Start trial</a>
+            <a class="button" target="_blank" rel="noopener noreferrer" href="//cloud.rocket.chat/trial/large">Start trial</a>
           </td>
         </tr>
         <tr>
@@ -239,7 +239,7 @@ redirect_from:
         </tr>
         <tr>
           <td>
-            <p>50.000 users</p>
+            <p>50,000 users</p>
             <p>Up to 500 concurrent users </p>
           </td>
         </tr>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@ redirect_from:
         <h1 class="display--big theme_type--dark">Open Source Team Communication</h1>
         <p class="display--small theme_type--grey">Rocket.Chat is free, unlimited and open source. Replace email &amp; Slack with the ultimate team chat software solution.</p>
         <div class="install">
-          <a href="/cloud" target="_blank" rel="noopener noreferrer" class="button">Start cloud trial</a>
+          <a href="/cloud" rel="noopener noreferrer" class="button">Start cloud trial</a>
           <a href="/install" class="button button--ghost">Install own server</a>
         </div>
       </div>


### PR DESCRIPTION
Fixed:
* Links to the plans
* Removed target blank on home page when going to /cloud
* Changed from dot notation to comma.