### PR TITLE
Clarify meaning of basic support plan

### DIFF
--- a/support.html
+++ b/support.html
@@ -246,7 +246,7 @@ redirect_from:
           <p class="theme_type--grey">Displayed prices are for an annual contract.</p>
 
           <h3 class="theme_type--dark"><strong>Cloud Support</strong></h3>
-          <p class="theme_type--grey">The Basic support plan is included for paying Cloud customers. Cloud is not automatically included for Basic support plan on-premises clients, who will need to purchase this separately.</p>
+          <p class="theme_type--grey">The Basic support plan is included for paying Cloud customers. Cloud not included with basic support plan.</p>
 
           <h3 class="theme_type--dark"><strong>Point of contact</strong></h3>
           <p class="theme_type--grey">Support plans do not include end users. Once a support plan has been purchased it is the business's responsiblity to inform Rocket.Chat who will be their internal point of contact for the support plan. Up to three contacts are permitted per organization. </p>

--- a/support.html
+++ b/support.html
@@ -130,7 +130,7 @@ redirect_from:
             <th><span>rocket.chat cloud</span></th>
           </tr>
           <tr>
-            <td><p><img src="/images/default/check.svg" /> Rocket.Chat Cloud Included</p></td>
+            <td><p><img src="/images/default/check.svg" /> Basic Support Plan incl. for Rocket.Chat Cloud customers</p></td>
           </tr>
           <tr>
             <th><span>Support SLA</span></th>
@@ -190,7 +190,7 @@ redirect_from:
             <th><span>rocket.chat cloud</span></th>
           </tr>
           <tr>
-            <td><p>Rocket.Chat Cloud from <strong>$749 /mo</strong></p></td>
+            <td><p>Premium Support Plan is available from <strong>$749 /mo</strong></p></td>
           </tr>
           <tr>
             <th><span>Support SLA</span></th>
@@ -236,7 +236,7 @@ redirect_from:
   <div class="flex-grid grid--justify-around">
     <div class="col--three-quarter">
       <h2 class="display--small theme_type--dark"><strong>Premium Support Explained</strong></h2>
-      <p class="display--small theme_type--grey">All you need to know</p>
+      <p class="display--small theme_type--grey">All your questions answered</p>
 
       <br />
 
@@ -245,17 +245,22 @@ redirect_from:
           <h3 class="theme_type--dark"><strong>Pricing &amp; Billing</strong></h3>
           <p class="theme_type--grey">Displayed prices are for an annual contract.</p>
 
+          <h3 class="theme_type--dark"><strong>Cloud Support</strong></h3>
+          <p class="theme_type--grey">The Basic support plan is included for paying Cloud customers. Cloud is not automatically included for Basic support plan on-premises clients, who will need to purchase this separately.</p>
+
           <h3 class="theme_type--dark"><strong>Point of contact</strong></h3>
           <p class="theme_type--grey">Support plans do not include end users. Once a support plan has been purchased it is the business's responsiblity to inform Rocket.Chat who will be their internal point of contact for the support plan. Up to three contacts are permitted per organization. </p>
 
           <h3 class="theme_type--dark"><strong>Critical business impact</strong></h3>
           <p class="theme_type--grey">An issue affecting Rocket.Chat that prevents a business from operating as normal. Examples include: data loss or corruption; system crashes; loss of critical functionality; large numbers of users unable to work. </p>
 
-          <h3 class="theme_type--dark"><strong>Minimal business impact</strong></h3>
-          <p class="theme_type--grey">A question, feature request or documentation issue that does not have an impact on performance.</p>
         </div>
 
         <div class="col">
+
+          <h3 class="theme_type--dark"><strong>Minimal business impact</strong></h3>
+          <p class="theme_type--grey">A question, feature request or documentation issue that does not have an impact on performance.</p>
+
           <h3 class="theme_type--dark"><strong>Self-help resources</strong></h3>
           <p class="theme_type--grey">Rocket.Chat provides user information for adminstrators, end users and developers at <a href="/docs" class="button--link">https://rocket.chat/docs.</a></p>
 


### PR DESCRIPTION
I was asked to make it clear that Cloud is not included for on-premises clients. I have re-worded the support table and added a Cloud Support section in the FAQ type section at the bottom of the page.