### PR TITLE
Swap copy in Global Resellers and Technology Partners sections.

### DIFF
--- a/partners.html
+++ b/partners.html
@@ -38,7 +38,7 @@ theme: dark
     <div class="col--haft">
       <p class="label">Our partners</p>
       <h2 class="display theme_type--dark">Global Resellers</h2>
-      <p class="display--small theme_type--grey">From installation and configuration to the development of features, bots and integrations, Global Partners develop Rocket.Chat's code and come up with new features to upgrade your platform</p>
+      <p class="display--small theme_type--grey">These partners sell Rocket.Chat on our behalf.</p>
     </div>
   </div>
 
@@ -67,6 +67,9 @@ theme: dark
     <div class="col--haft">
       <p class="label">Our partners</p>
       <h2 class="display theme_type--dark">Technology Partners</h2>
+      <p class="display--small theme_type--grey">From installation and configuration to the development of features, bots and integrations, Technology Partners develop Rocket.Chat's code and
+        come up with new features to upgrade your platform.
+      </p>
     </div>
   </div>
 


### PR DESCRIPTION
They must have been swapped with the new website.