### PR TITLE
Add illustration to concession page + copy edits

### DIFF
--- a/concession.html
+++ b/concession.html
@@ -23,8 +23,8 @@ theme: dark
 <section class="container">
   <div class="flex-grid grid--justify-around">
     <div class="col--three-quarter">
-      <center><h2 class="display--small theme_type--dark" id="non-profits"><strong>Non-Profits</strong></h2></center>
-      <center><p class="display--small theme_type--grey">Eligible non-profit organizations can receive discounted rates on Rocket.Chat Cloud Hosting.</p></center>
+      <center><h2 class="display--small theme_type--dark" id="non-profits"><strong>Non-Profit Organizations</strong></h2></center>
+      <center><p class="display--small theme_type--grey">Eligible NGOs can receive discounted rates on Rocket.Chat Cloud Hosting</p></center>
 
       <br />
 

--- a/concession.html
+++ b/concession.html
@@ -23,8 +23,8 @@ theme: dark
 <section class="container">
   <div class="flex-grid grid--justify-around">
     <div class="col--three-quarter">
-      <h2 class="display--small theme_type--dark" id="non-profits"><strong>Non-Profits</strong></h2>
-      <p class="display--small theme_type--grey">Eligible non-profit organizations can receive discounted rates on Rocket.Chat Cloud Hosting.</p>
+      <center><h2 class="display--small theme_type--dark" id="non-profits"><strong>Non-Profits</strong></h2></center>
+      <center><p class="display--small theme_type--grey">Eligible non-profit organizations can receive discounted rates on Rocket.Chat Cloud Hosting.</p></center>
 
       <br />
 

--- a/concession.html
+++ b/concession.html
@@ -1,24 +1,30 @@
 ---
 layout: en/default
 class: concession
-title: "Free Rocket.Chat Cloud for non-profits or educational institutes"
+title: "Free Rocket.Chat Cloud for non-profit organizations or educational institutions"
 permalink: /concession
 redirect_from: /concession/
 theme: dark
 ---
 
-<section class="hero">
+<section class="container hero">
   <h1 class="display--big theme_type--dark">Causes we support</h1>
-  <p class="display--small theme_type--grey">We offer special rates for people who do good things around the world</p>
+  <p class="display--small theme_type--grey">We offer special rates to people who do good things around the world</p>
 
   <img src="/images/press/hero@2x.jpg" />
 </section>
+
+<div class="space--10"></div>
+
+<div class="space--5"></div>
+
+<div class="space--2"></div>
 
 <section class="container">
   <div class="flex-grid grid--justify-around">
     <div class="col--three-quarter">
       <h2 class="display--small theme_type--dark" id="non-profits"><strong>Non-Profits</strong></h2>
-      <p class="display--small theme_type--grey">Eligible nonprofits can receive discounted rates on Rocket.Chat Cloud Hosting.</p>
+      <p class="display--small theme_type--grey">Eligible non-profit organizations can receive discounted rates on Rocket.Chat Cloud Hosting.</p>
 
       <br />
 
@@ -30,7 +36,7 @@ theme: dark
             <li class="theme_type--grey">The organization must not discriminate by gender, race, ethnicity, religion, political affiliation, sexual orientation, nationality or any other kind.</li><br/>
             <li class="theme_type--grey">Organizations that are not included: private foundations, government offices, legislative or political organizations, organizations that aim to influence public opinion, churches or other type of religious association.</li><br/>
           </ol>
-          <p class="theme_type--grey">If you meet at least one of the above requirements and would like to apply for a concession please <a href="{{ site.url }}/contact">contact us</a>.</p>
+          <p class="theme_type--grey">If you meet at least one of the above requirements and would like to apply for a concession please <strong><a href="{{ site.url }}/contact">contact us</a></strong>.</p>
         </div>
 
         <div class="col">
@@ -47,7 +53,7 @@ theme: dark
           </ol>
 
           <p class="theme_type--grey">
-            If you meet at least one of the above requirements and would like to apply for a concession please <a href="{{ site.url }}/contact">contact us</a>.
+            If you meet at least one of the above requirements and would like to apply for a concession please <strong><a href="{{ site.url }}/contact">contact us</a></strong>.
           </p>
         </div>
       </div>

--- a/concession.html
+++ b/concession.html
@@ -10,6 +10,8 @@ theme: dark
 <section class="hero">
   <h1 class="display--big theme_type--dark">Causes we support</h1>
   <p class="display--small theme_type--grey">We offer special rates for people who do good things around the world</p>
+
+  <img src="/images/press/hero@2x.jpg" />
 </section>
 
 <section class="container">

--- a/press.html
+++ b/press.html
@@ -14,6 +14,7 @@ theme: dark
   <img src="/images/press/hero@2x.jpg" />
 </section>
 
+<div class="space--4"></div>
 
 <section class="container">
   <div class="flex-grid grid--justify-around">


### PR DESCRIPTION
Add illustration to Concession page:
![image](https://user-images.githubusercontent.com/36157246/41304224-7397fee0-6e67-11e8-926b-8f572dc6d792.png)

Same as Press one but Concession is not linked to, and is not very visible. Very compatible in terms of illustration subject. 
Minor copy edits to the page too, and styling of page + illustration.