### PR TITLE
Remove implication that the Rocket.Chat software is built onto the blockchain

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@ redirect_from:
       </div>
 
       <div class="col--third">
-        <h3 class="theme_type--dark display--small"><strong>Security</strong></h3>
+        <h3 class="theme_type--dark display--small"><strong>Top-class security</strong></h3>
         <p class="theme_type--grey">A safe workspace with username restriction and admin transparency. Remove bad actors by adding moderators and provide admins with additional controls.</p>
         {% comment %} <p><a href="" class="button--link button--with-arrow">Learn more</a> {% endcomment %}
       </div>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@ redirect_from:
 
     <div class="flex-grid grid--justify-around">
       <div class="col--third">
-        <h3 class="theme_type--dark display--small"><strong>Blockchain</strong></h3>
+        <h3 class="theme_type--dark display--small"><strong>Trusted by blockchain innovators</strong></h3>
         <p class="theme_type--grey">Join leading blockchain projects such as Aragon, Hyperledger, Golem and others in migrating from Slack. Do so with ease thanks to Slack Import and Slack Bridge. </p>
         {% comment %}  <p><a href="" class="button--link button--with-arrow">Learn more</a> {% endcomment %}
       </div>

--- a/index.html
+++ b/index.html
@@ -99,14 +99,14 @@ redirect_from:
 
     <div class="flex-grid grid--justify-around">
       <div class="col--third">
-        <h3 class="theme_type--dark display--small"><strong>Trusted by blockchain innovators</strong></h3>
-        <p class="theme_type--grey">Join leading blockchain projects such as Aragon, Hyperledger, Golem and others in migrating from Slack. Do so with ease thanks to Slack Import and Slack Bridge. </p>
+        <h3 class="theme_type--dark display--small"><strong>Secure Conversations</strong></h3>
+        <p class="theme_type--grey">A safe workspace with username restriction and admin transparency. Remove bad actors by adding moderators and provide admins with additional controls.</p>
         {% comment %}  <p><a href="" class="button--link button--with-arrow">Learn more</a> {% endcomment %}
       </div>
 
       <div class="col--third">
-        <h3 class="theme_type--dark display--small"><strong>Top-class security</strong></h3>
-        <p class="theme_type--grey">A safe workspace with username restriction and admin transparency. Remove bad actors by adding moderators and provide admins with additional controls.</p>
+        <h3 class="theme_type--dark display--small"><strong>Trusted by blockchain innovators</strong></h3>
+        <p class="theme_type--grey">Join leading blockchain projects such as Aragon, Hyperledger, Golem and others in migrating from Slack. Do so with ease thanks to Slack Import and Slack Bridge.</p>
         {% comment %} <p><a href="" class="button--link button--with-arrow">Learn more</a> {% endcomment %}
       </div>
     </div>


### PR DESCRIPTION
The current heading "Blockchain" on the front page implies that the software's backend uses blockchain technology. This PR removes that bad implication and replaces it with a more honest yet appealing heading.
It also lengthens the second heading next to it to keep the headings symmetrical (for style).

**Before**
![2018-06-22_17-03-20](https://user-images.githubusercontent.com/39674991/41783992-a4278254-763e-11e8-9449-105a3a15d3c2.png)

**After**
![2018-06-22_17-03-12](https://user-images.githubusercontent.com/39674991/41783995-a903884a-763e-11e8-929d-6f5b285a57ff.png)