### PR TITLE
Change date on Zapier post to coincide with Zapier coming out of beta…

### DIFF
--- a/_posts/2018/08/2018-08-16-public-launch.md
+++ b/_posts/2018/08/2018-08-16-public-launch.md
@@ -2,7 +2,7 @@
 title: "Rocket.Chat's Zapier App now public"
 categories:
   - News
-date: 2018-07-01 08:00:00
+date: 2018-08-16 08:00:00
 author: Isabella Russell
 cover: /images/posts/2018/07/2018-07-01-zapier-public-launch/zapier&RC.png
 featured: true


### PR DESCRIPTION
Change date to today as Zapier app goes public today. 