### PR TITLE
Stop redirecting to webnar pages

### DIFF
--- a/_layouts/en/default.html
+++ b/_layouts/en/default.html
@@ -46,7 +46,7 @@ layout: default
         <li><a href="/cloud">Cloud</a></li>
         <li><a href="/bots">Bots</a></li>
         <li><a href="/community">Community</a></li>
-        <li><a href="/webinars/">Webinars</a></li>
+        <li><a href="/webinars">Webinars</a></li>
         <li><a href="/docs/">Documentation</a></li>
       </ul>
     </div>


### PR DESCRIPTION
If you go to the webnars page from the footer link you will see a white screen redirecting to the actual page. Removing the slash at the end of the link fixes this.