### PR TITLE
[FIX] Update team page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ paginate_path: /blog/page/:num/
 paginate: 8
 
 # bump if alterting styles
-version: 44
+version: 45
 # read speed
 wpm: 160
 

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -99,14 +99,6 @@
   photo: yes
   country: Brazil
 
-- name: Manish Kakoti
-  role: Federation Engineer
-  github_username: madguy02
-  github_uid: 8217234
-  department: Development
-  username: madguy02
-  country: India
-
 - name: Filipe Brito
   role: Android Engineer
   github_username: filipedelimabrito

--- a/_sass/pages/team.scss
+++ b/_sass/pages/team.scss
@@ -239,29 +239,34 @@
   margin-bottom: 5em;
   background-repeat: no-repeat;
   background-image: url("/images/posts/2018/04/2018-04-18-rocket-chat-summit-2018/rocket-chat-team-summit-2018.jpg");
-  background-position: center bottom;
-  background-size: auto 20em;
-  padding-bottom: 20em;
+  background-position: center;
+  background-size: cover;
 
-  @media (min-width: $tablet) {
+  .wrap {
+    background-color: rgba(18,31,51,0.8);
+    padding: 3em 4em;
+    max-width: 50%;
+  }
+
+  @media (max-width: $tablet) {
     @include flexbox();
     padding-bottom: 1.5em;
-    background-size: auto 75%;
-    background-position: right -40% bottom;
     margin-bottom: 7em;
 
     .wrap {
       padding: 2em;
-      max-width: 30%;
+      max-width: 80%;
     }
   }
 
-  @media (min-width: 62em) {
-    background-position: right bottom;
+  @media (max-width: $mobile) {
+    background-color: $space-grey;
+    background-image: unset;
+    padding-bottom: 2em;
 
     .wrap {
-      padding: 3em 4em;
-      max-width: 50%;
+      max-width: 100%;
+      padding: 0;
     }
   }
 }

--- a/_sass/ui/variables.scss
+++ b/_sass/ui/variables.scss
@@ -28,3 +28,4 @@ $gutter: 1em; // 32px;
 $gutter-larger: 2em; // 16px;
 $container: 74em; // 1184px;
 $tablet: 48.1em; // 768px;
+$mobile: 415px;

--- a/team.html
+++ b/team.html
@@ -168,8 +168,8 @@ theme: dark
         </p>
       </div>
     </div>
-
-    <div class="team-map__pin india">
+    <!-- Please uncomment here if we have a new team member from india -->
+    <!-- <div class="team-map__pin india">
       <div class="team-map__profile">
         <div class="flags">
           {% for member in IndiaTeam %}
@@ -191,7 +191,7 @@ theme: dark
           <span><img src="/images/flags/India.png" alt="India" /></span>
         </p>
       </div>
-    </div>
+    </div> -->
   </div>
 </section>
 

--- a/team.html
+++ b/team.html
@@ -201,8 +201,7 @@ theme: dark
       <p class="label theme_type--grey"></p>
       <h2 class="display theme_type--dark">About Us</h2>
       <p class="theme_type--grey">Rocket.Chat is more than your average company, we are the leading open source team chat community. When you choose Rocket.Chat, you become part of a global community comprised of a core team, hundreds of open source developers, testers and writers, and millions of users.</p>
-      <p class="theme_type--grey">We are building the future of communication and would love to build it with you. We are often looking for more team members, so check out our<p class="theme_type--grey">We are building the future of communication and would love to build it with you. We are often looking for more
-      team members, so check out our <a href="https://rocketchat.recruitee.com">https://rocketchat.recruitee.com <b>Jobs page</b></a> for opportunities!</p>
+      <p class="theme_type--grey">We are building the future of communication and would love to build it with you. We are often looking for more team members, so check out our <a href="https://rocketchat.recruitee.com"><b>Jobs page</b></a> for opportunities!</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
closes #459 
This fixes the broken about us element, and updates the team list.
Before:
![image](https://user-images.githubusercontent.com/20868078/46029992-4b5bc680-c0cb-11e8-8383-d03900399524.png)

After:
![image](https://user-images.githubusercontent.com/20868078/46031394-20737180-c0cf-11e8-89db-17a9586c8b5e.png)

