### PR TITLE
Fix GitHub buttons vertical align

### DIFF
--- a/_sass/components/footer.scss
+++ b/_sass/components/footer.scss
@@ -115,7 +115,7 @@
   height: 36px;
   text-align: center;
   font-size: 0.8em;
-  line-height: 2.5;
+  line-height: 36px;
   transition: all 0.3s ease;
 
   img {


### PR DESCRIPTION
Look at `Star or fork on GitHub` buttons

Before:
![image](https://user-images.githubusercontent.com/8591547/46491535-5e644a00-c7e1-11e8-82ce-d817e05f7982.png)

After:
![image](https://user-images.githubusercontent.com/8591547/46491510-51475b00-c7e1-11e8-9348-d50bed2a1c08.png)
