### PR TITLE
[FIX] Add parallax effect back to pricing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,7 +6,7 @@ paginate_path: /blog/page/:num/
 paginate: 8
 
 # bump if alterting styles
-version: 66
+version: 68
 # read speed
 wpm: 160
 

--- a/main.js
+++ b/main.js
@@ -295,7 +295,7 @@ if (document.querySelector(".js-download")) {
     var homeMail = document.querySelector(".home-landingpage__mail");
     var homeChat = document.querySelector(".home-landingpage__chat");
     var support = document.querySelector(".support-hero__image");
-    var cloud = document.querySelector(".cloud-hero__image");
+    var cloud = document.querySelector(".pricing-hero__image");
     var install = document.querySelector(".install-hero__image");
     var partners = document.querySelector(".partners-hero__image");
     var partnersBody = document.querySelector("body.partners");


### PR DESCRIPTION
Apparently most of the site uses a very subtle parallax effect on their backgrounds, the new pricing page broke that. This PR simply adds this effect back to it