### PR TITLE
Bump desktop app version

### DIFF
--- a/_data/install.yml
+++ b/_data/install.yml
@@ -1,5 +1,5 @@
 desktop:
-  version: 2.14.1
+  version: 2.14.5
   windowsSize: 68 MB
   macosSize: 51 MB
   linuxSize: 35 MB


### PR DESCRIPTION
Version 2.14.5: https://github.com/RocketChat/Rocket.Chat.Electron/releases/tag/2.14.5