### PR TITLE
Press page font color fixed

### DIFF
--- a/_sass/pages/press.scss
+++ b/_sass/pages/press.scss
@@ -1,4 +1,7 @@
 body.press {
+  .white-font {
+    color: #fff;
+  }
   .hero {
     overflow: hidden;
 

--- a/_sass/pages/press.scss
+++ b/_sass/pages/press.scss
@@ -1,7 +1,4 @@
 body.press {
-  .white-font {
-    color: #fff;
-  }
   .hero {
     overflow: hidden;
 

--- a/press.html
+++ b/press.html
@@ -77,7 +77,7 @@ theme: dark
             <div class="flex-grid--nobreak">
               <div class="col no-gutter">
                 <div class="select select-download">
-                  <select class="js-select-download white-font" data-target="{{ logo.file }}">
+                  <select class="js-select-download theme_type--dark" data-target="{{ logo.file }}">
                     {% if logo.png %}<option value="/images/press/logos/{{ logo.file }}.png" >PNG</option>{% endif %}
                     {% if logo.svg %}<option value="/images/press/logos/{{ logo.file }}.svg" title="{{ logo.name }} SVG">SVG</option>{% endif %}
                   </select>

--- a/press.html
+++ b/press.html
@@ -77,7 +77,7 @@ theme: dark
             <div class="flex-grid--nobreak">
               <div class="col no-gutter">
                 <div class="select select-download">
-                  <select class="js-select-download" data-target="{{ logo.file }}">
+                  <select class="js-select-download white-font" data-target="{{ logo.file }}">
                     {% if logo.png %}<option value="/images/press/logos/{{ logo.file }}.png" >PNG</option>{% endif %}
                     {% if logo.svg %}<option value="/images/press/logos/{{ logo.file }}.svg" title="{{ logo.name }} SVG">SVG</option>{% endif %}
                   </select>


### PR DESCRIPTION
Fixing font color on press page _Logos and Assets area_
Changing from dark to white "Fixes #613" "Closes #643"
@rafaelks check to confirm.
@MartinSchoeler Here is the fixed PR.


![jkdjfk](https://user-images.githubusercontent.com/39289592/53518800-19afb700-3ad2-11e9-8e26-124aa09f2554.png)
