### PR TITLE
Remove "Updates" from pricing page

### DIFF
--- a/_data/pricing.yml
+++ b/_data/pricing.yml
@@ -294,14 +294,6 @@
 - title: "Support"
   isHeader: true
 
-- title: "Updates"
-  community: "Regular Releases"
-  pro: "Priority Patches"
-  enterprise: "Priority Patches"
-  bronze: "Automatic"
-  silver: "Automatic"
-  gold: "Automatic"
-
 - title: "SLA - Monthly Uptime"
   bronze: ""
   silver: "99.99%"


### PR DESCRIPTION
Since we don't have a clear explanation or schedule for different types of updates, it's best to remove this information from the pricing page for now to avoid confusion.