### PR TITLE
Scaling home-hero-image to not shrink or stretch

### DIFF
--- a/_sass/pages/home.scss
+++ b/_sass/pages/home.scss
@@ -113,6 +113,10 @@
   position: relative;
   right: -$gutter;
   margin-bottom: 2em;
+  display: block;
+  max-height:700px;
+  width: auto;
+  height: auto;
 
   @media screen and (min-width: $tablet) {
     position: absolute;


### PR DESCRIPTION
As seen before it stretches.

![shrinks](https://user-images.githubusercontent.com/39289592/54788268-b9beb300-4c2e-11e9-9fd3-f51c62e48d52.png)

After edit, we have a better display with no stretch or shrink

![stretch-none](https://user-images.githubusercontent.com/39289592/54788341-f8546d80-4c2e-11e9-88e6-c84b168f14f4.png)

"Closes: #414" "Closes: #680 "  @MartinSchoeler verify to confirm.