### PR TITLE
[Deprecated] Fix cannot read property 'style' of undefined problem

### DIFF
--- a/main.js
+++ b/main.js
@@ -454,6 +454,9 @@ showSlides();
 function showSlides() {
   var i;
   var slides = document.getElementsByClassName("fade");
+
+  if(slides.length === 0) return; // the following code will not be run if not on the home page.
+
   for (i = 0; i < slides.length; i++) {
     slides[i].style.opacity = "0";
     // slides[i].style.display = "none";


### PR DESCRIPTION
Closes [docs#1178](https://github.com/RocketChat/docs/issues/1178).

**Description:**
The function [showSlides()](https://github.com/RocketChat/rocketchat.github.io/blob/54fe42517beff3c589590c3ed00c9f8b15463976/main.js#L454) in project [rocketchat.github.io/main.js](https://github.com/RocketChat/rocketchat.github.io/blob/54fe42517beff3c589590c3ed00c9f8b15463976/main.js#L454) is designed for slideshows in [Homepage](https://rocket.chat/) as shown below. 

![image](https://user-images.githubusercontent.com/32427260/55271985-0ec68d00-52f1-11e9-9862-09fd6aba92c5.png)

But in other pages, if there are not any elements with class attribute `fade` in the page, **Uncaught TypeError** will be thrown in the console. Please review my patch for detail :)