### PR TITLE
Remove legacy verbiage

### DIFF
--- a/legal/cloud/terms.md
+++ b/legal/cloud/terms.md
@@ -21,7 +21,7 @@ These Customer Terms form a part of a binding "Contract" between Customer and us
 
 **Customer Data**
 
-When a User (including you) submits content or information to the Services, such as messages or files (“User Data”), you acknowledge and agree that the Customer Data is owned by Rocket.Chat he retains ownership of any intellectual property rights in that content. 
+When a User (including you) submits content or information to the Services, such as messages or files (“User Data”), he retains ownership of any intellectual property rights in that content. 
 
 With regards to Services operated directly by Rocket.Chat:
 

--- a/legal/cloud/terms.md
+++ b/legal/cloud/terms.md
@@ -21,7 +21,7 @@ These Customer Terms form a part of a binding "Contract" between Customer and us
 
 **Customer Data**
 
-When a User (including you) submits content or information to the Services, such as messages or files (“User Data”), he retains ownership of any intellectual property rights in that content. 
+When a User (including you) submits content or information to the Services, such as messages or files (“User Data”), the Customer retains ownership of any intellectual property rights in that content. 
 
 With regards to Services operated directly by Rocket.Chat:
 


### PR DESCRIPTION
Removed legacy verbiage which should have been deleted by the last PR, now clarifying data ownership of user