### PR TITLE
[FIX] Update Livechat script

### DIFF
--- a/_includes/livechat.html
+++ b/_includes/livechat.html
@@ -3,8 +3,8 @@
  	(function(w, d, s, u) {
 		w.RocketChat = function(c) { w.RocketChat._.push(c) }; w.RocketChat._ = []; w.RocketChat.url = u;
 		var h = d.getElementsByTagName(s)[0], j = d.createElement(s);
-		j.async = true; j.src = 'https://rocketchatsales.rocket.chat/livechat/1.0.0/rocketchat-livechat.min.js?_=201903270000';
+		j.async = true; j.src = 'https://rocketchatsales.rocket.chat/livechat/rocketchat-livechat.min.js?_=201903270000';
 		h.parentNode.insertBefore(j, h);
-	})(window, document, 'script', 'https://rocketchatsales.rocket.chat/livechat?version=1.0.0');
+	})(window, document, 'script', 'https://rocketchatsales.rocket.chat/livechat');
  </script>
  <!-- End of Rocket.Chat Livechat Script -->


### PR DESCRIPTION
Update the Livechat script, removing `1.0.0` from the public path.
The Widget is not working properly on Rocket.Chat website.