### PR TITLE
Delete redirect.js

### DIFF
--- a/redirect.js
+++ b/redirect.js
@@ -1,5 +1,0 @@
-// redirect people to rocket.chat/docs if they try and browse the GitHub pages version
-
-if((location.hostname == "rocketchat.github.io" || location.hostname == "www.rocket.chat") && location.href.indexOf('?noredirect') == -1) {
-	location="https://rocket.chat" + location.pathname
-}


### PR DESCRIPTION
Since this site is open-sourced, why not let users use the GH Pages version?